### PR TITLE
Vast changes to the ElementNode update system

### DIFF
--- a/Flighter/BuildContext.cs
+++ b/Flighter/BuildContext.cs
@@ -12,5 +12,23 @@ namespace Flighter
         {
             this.constraints = constraints;
         }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is BuildContext))
+            {
+                return false;
+            }
+
+            var context = (BuildContext)obj;
+            return EqualityComparer<BoxConstraints>.Default.Equals(constraints, context.constraints);
+        }
+
+        public override int GetHashCode()
+        {
+            return -1144114365 + EqualityComparer<BoxConstraints>.Default.GetHashCode(constraints);
+        }
+
+        public override string ToString() => "Constraints: " + constraints;
     }
 }

--- a/Flighter/BuildResult.cs
+++ b/Flighter/BuildResult.cs
@@ -17,5 +17,21 @@ namespace Flighter
         {
             this.size = size;
         }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is BuildResult))
+            {
+                return false;
+            }
+
+            var result = (BuildResult)obj;
+            return EqualityComparer<Size>.Default.Equals(size, result.size);
+        }
+
+        public override int GetHashCode()
+        {
+            return -1803920452 + EqualityComparer<Size>.Default.GetHashCode(size);
+        }
     }
 }

--- a/Flighter/Core/Align.cs
+++ b/Flighter/Core/Align.cs
@@ -54,6 +54,40 @@ namespace Flighter.Core
             if (value < 0 || value > 1)
                 throw new ArgumentOutOfRangeException("Alignment value must be between 0.0 and 1.0.");
         }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Alignment))
+            {
+                return false;
+            }
+
+            var alignment = (Alignment)obj;
+            return Horizontal == alignment.Horizontal &&
+                   horizontal == alignment.horizontal &&
+                   Vertical == alignment.Vertical &&
+                   vertical == alignment.vertical;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 801727432;
+            hashCode = hashCode * -1521134295 + Horizontal.GetHashCode();
+            hashCode = hashCode * -1521134295 + horizontal.GetHashCode();
+            hashCode = hashCode * -1521134295 + Vertical.GetHashCode();
+            hashCode = hashCode * -1521134295 + vertical.GetHashCode();
+            return hashCode;
+        }
+
+        public static bool operator ==(Alignment alignment1, Alignment alignment2)
+        {
+            return alignment1.Equals(alignment2);
+        }
+
+        public static bool operator !=(Alignment alignment1, Alignment alignment2)
+        {
+            return !(alignment1 == alignment2);
+        }
     }
 
     public class Align : LayoutWidget
@@ -67,12 +101,20 @@ namespace Flighter.Core
             this.alignment = alignment;
         }
 
-        public override bool IsSame(Widget other)
+        public override bool Equals(object obj)
         {
-            return 
-                other is Align c && 
-                child == c.child && 
-                alignment.Equals(c.alignment);
+            var align = obj as Align;
+            return align != null &&
+                   child.Equals(align.child) &&
+                   alignment == align.alignment;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1394767171;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Widget>.Default.GetHashCode(child);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Alignment>.Default.GetHashCode(alignment);
+            return hashCode;
         }
 
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)

--- a/Flighter/Core/Animation.cs
+++ b/Flighter/Core/Animation.cs
@@ -211,7 +211,6 @@ namespace Flighter.Core
         {
             
             subscribedController = GetWidget<Animation>().controller;
-            Console.WriteLine("Init animation" + subscribedController);
             subscribedController.ValueChanged += OnValueChanged;
         }
 
@@ -238,7 +237,6 @@ namespace Flighter.Core
 
         void OnValueChanged(float _)
         {
-            Console.WriteLine("Animation value changed");
             // Just set state to trigger an update and rebuild.
             SetState(null);
         }

--- a/Flighter/Core/Animation.cs
+++ b/Flighter/Core/Animation.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace Flighter.Core
 {
     public delegate void AnimationUpdate(float value);
-    public delegate Widget AnimationBuilder(float t);
+    public delegate Widget AnimationBuilder(float t, BuildContext context);
     public delegate float Curve(float f);
 
     public enum AnimationDirection
@@ -232,7 +232,7 @@ namespace Flighter.Core
         {
             var w = GetWidget<Animation>();
 
-            return w.builder(w.controller.Value);
+            return w.builder(w.controller.Value, context);
         }
 
         void OnValueChanged(float _)

--- a/Flighter/Core/Animation.cs
+++ b/Flighter/Core/Animation.cs
@@ -201,6 +201,22 @@ namespace Flighter.Core
         }
 
         public override State CreateState() => new AnimationState();
+
+        public override bool Equals(object obj)
+        {
+            var animation = obj as Animation;
+            return animation != null &&
+                   EqualityComparer<AnimationBuilder>.Default.Equals(builder, animation.builder) &&
+                   EqualityComparer<AnimationController>.Default.Equals(controller, animation.controller);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -639548479;
+            hashCode = hashCode * -1521134295 + EqualityComparer<AnimationBuilder>.Default.GetHashCode(builder);
+            hashCode = hashCode * -1521134295 + EqualityComparer<AnimationController>.Default.GetHashCode(controller);
+            return hashCode;
+        }
     }
 
     class AnimationState : State

--- a/Flighter/Core/Animation.cs
+++ b/Flighter/Core/Animation.cs
@@ -205,16 +205,28 @@ namespace Flighter.Core
 
     class AnimationState : State
     {
+        AnimationController subscribedController;
+
         public override void Init()
         {
-            var w = GetWidget<Animation>();
+            
+            subscribedController = GetWidget<Animation>().controller;
+            Console.WriteLine("Init animation" + subscribedController);
+            subscribedController.ValueChanged += OnValueChanged;
+        }
 
-            w.controller.ValueChanged += OnValueChanged;
+        public override void WidgetChanged()
+        {
+            if (subscribedController != null)
+                subscribedController.ValueChanged -= OnValueChanged;
+            Init();
         }
 
         public override void Dispose()
         {
-            GetWidget<Animation>().controller.ValueChanged -= OnValueChanged;
+            if (subscribedController != null)
+                subscribedController.ValueChanged -= OnValueChanged;
+            subscribedController = null;
         }
 
         public override Widget Build(BuildContext context)
@@ -226,6 +238,7 @@ namespace Flighter.Core
 
         void OnValueChanged(float _)
         {
+            Console.WriteLine("Animation value changed");
             // Just set state to trigger an update and rebuild.
             SetState(null);
         }

--- a/Flighter/Core/BoxConstrained.cs
+++ b/Flighter/Core/BoxConstrained.cs
@@ -15,6 +15,22 @@ namespace Flighter.Core
             this.constraints = constraints;
         }
 
+        public override bool Equals(object obj)
+        {
+            var constrained = obj as BoxConstrained;
+            return constrained != null &&
+                   EqualityComparer<Widget>.Default.Equals(child, constrained.child) &&
+                   EqualityComparer<BoxConstraints>.Default.Equals(constraints, constrained.constraints);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1456531856;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Widget>.Default.GetHashCode(child);
+            hashCode = hashCode * -1521134295 + EqualityComparer<BoxConstraints>.Default.GetHashCode(constraints);
+            return hashCode;
+        }
+
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)
         {
             var childNode = node.AddChildWidget(child, new BuildContext(constraints));

--- a/Flighter/Core/Clip.cs
+++ b/Flighter/Core/Clip.cs
@@ -18,6 +18,18 @@ namespace Flighter.Core
 
         public override Element CreateElement() => new ClipElement();
 
+        public override bool Equals(object obj)
+        {
+            var clip = obj as Clip;
+            return clip != null &&
+                   EqualityComparer<Widget>.Default.Equals(child, clip.child);
+        }
+
+        public override int GetHashCode()
+        {
+            return -1589309467 + EqualityComparer<Widget>.Default.GetHashCode(child);
+        }
+
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)
         {
             var childNode = node.AddChildWidget(child, context);

--- a/Flighter/Core/Clip.cs
+++ b/Flighter/Core/Clip.cs
@@ -27,6 +27,8 @@ namespace Flighter.Core
 
     class ClipElement : Element
     {
+        public override string Name => "Clip";
+
         protected override void _Init()
         {
             var clipComponent = componentProvider.CreateComponent<ClipComponent>();

--- a/Flighter/Core/ColoredBox.cs
+++ b/Flighter/Core/ColoredBox.cs
@@ -13,14 +13,21 @@ namespace Flighter.Core
             this.color = color;
         }
 
-        public override bool IsSame(Widget other)
-        {
-            return other is ColoredBox c && c.color.Equals(color);
-        }
-
         public override Element CreateElement()
         {
             return new ColoredBoxElement();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var box = obj as ColoredBox;
+            return box != null &&
+                   EqualityComparer<Color>.Default.Equals(color, box.color);
+        }
+
+        public override int GetHashCode()
+        {
+            return 790427672 + EqualityComparer<Color>.Default.GetHashCode(color);
         }
 
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)

--- a/Flighter/Core/Column.cs
+++ b/Flighter/Core/Column.cs
@@ -4,15 +4,8 @@ using System.Text;
 
 namespace Flighter.Core
 {
-    public class Column : StatelessWidget
+    public class Column : SequenceLayout
     {
-        public readonly List<Widget> children;
-        public readonly HorizontalDirection horizontalDirection;
-        public readonly VerticalDirection verticalDirection;
-        public readonly MainAxisAlignment mainAxisAlignment;
-        public readonly CrossAxisAlignment crossAxisAlignment;
-        public readonly MainAxisSize mainAxisSize;
-
         public Column(
             List<Widget> children,
             HorizontalDirection horizontalDirection = HorizontalDirection.LeftToRight,
@@ -20,23 +13,24 @@ namespace Flighter.Core
             MainAxisAlignment mainAxisAlignment = MainAxisAlignment.Start,
             CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.Start,
             MainAxisSize mainAxisSize = MainAxisSize.Max)
+            : base(
+                  children,
+                  Axis.Vertical,
+                  horizontalDirection,
+                  verticalDirection,
+                  mainAxisAlignment,
+                  crossAxisAlignment,
+                  mainAxisSize)
+        { }
+
+        public override bool Equals(object obj)
         {
-            this.children = children;
-            this.horizontalDirection = horizontalDirection;
-            this.verticalDirection = verticalDirection;
-            this.mainAxisAlignment = mainAxisAlignment;
-            this.crossAxisAlignment = crossAxisAlignment;
-            this.mainAxisSize = mainAxisSize;
+            return base.Equals(obj);
         }
 
-        public override Widget Build(BuildContext context)
-            => new SequenceLayout(
-                children,
-                Axis.Vertical,
-                horizontalDirection,
-                verticalDirection,
-                mainAxisAlignment,
-                crossAxisAlignment,
-                mainAxisSize);
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }

--- a/Flighter/Core/CoreComponents.cs
+++ b/Flighter/Core/CoreComponents.cs
@@ -1,5 +1,7 @@
 ﻿
 
+using System.Collections.Generic;
+
 namespace Flighter.Core
 {
     public delegate Widget WidgetBuilder();
@@ -37,6 +39,48 @@ namespace Flighter.Core
         public bool wrapLines;
         public TextOverflow textOverflow;
         public Color color;
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is TextStyle))
+            {
+                return false;
+            }
+
+            var style = (TextStyle)obj;
+            return EqualityComparer<IFontHandle>.Default.Equals(font, style.font) &&
+                   size == style.size &&
+                   lineSpacing == style.lineSpacing &&
+                   textAlign == style.textAlign &&
+                   fontStyle == style.fontStyle &&
+                   wrapLines == style.wrapLines &&
+                   textOverflow == style.textOverflow &&
+                   color == style.color;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1944643188;
+            hashCode = hashCode * -1521134295 + EqualityComparer<IFontHandle>.Default.GetHashCode(font);
+            hashCode = hashCode * -1521134295 + size.GetHashCode();
+            hashCode = hashCode * -1521134295 + lineSpacing.GetHashCode();
+            hashCode = hashCode * -1521134295 + textAlign.GetHashCode();
+            hashCode = hashCode * -1521134295 + fontStyle.GetHashCode();
+            hashCode = hashCode * -1521134295 + wrapLines.GetHashCode();
+            hashCode = hashCode * -1521134295 + textOverflow.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(color);
+            return hashCode;
+        }
+
+        public static bool operator ==(TextStyle style1, TextStyle style2)
+        {
+            return style1.Equals(style2);
+        }
+
+        public static bool operator !=(TextStyle style1, TextStyle style2)
+        {
+            return !(style1 == style2);
+        }
     }
 
     public abstract class TextComponent : Component
@@ -57,9 +101,43 @@ namespace Flighter.Core
             this.a = a;
         }
 
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Color))
+            {
+                return false;
+            }
+
+            var color = (Color)obj;
+            return r == color.r &&
+                   g == color.g &&
+                   b == color.b &&
+                   a == color.a;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -490236692;
+            hashCode = hashCode * -1521134295 + r.GetHashCode();
+            hashCode = hashCode * -1521134295 + g.GetHashCode();
+            hashCode = hashCode * -1521134295 + b.GetHashCode();
+            hashCode = hashCode * -1521134295 + a.GetHashCode();
+            return hashCode;
+        }
+
         public override string ToString()
         {
             return "r:" + r + ", g:" + g + ", b:" + b + ", a:" + a;
+        }
+
+        public static bool operator ==(Color color1, Color color2)
+        {
+            return color1.Equals(color2);
+        }
+
+        public static bool operator !=(Color color1, Color color2)
+        {
+            return !(color1 == color2);
         }
     }
 

--- a/Flighter/Core/EmptyBox.cs
+++ b/Flighter/Core/EmptyBox.cs
@@ -13,5 +13,9 @@ namespace Flighter.Core
         {
             return new BuildResult(context.constraints.MaxSize);
         }
+
+        public override bool Equals(object obj) => obj is EmptyBox;
+
+        public override int GetHashCode() => 0;
     }
 }

--- a/Flighter/Core/Flex.cs
+++ b/Flighter/Core/Flex.cs
@@ -23,12 +23,20 @@ namespace Flighter.Core
             return child;
         }
 
-        public override bool IsSame(Widget other)
+        public override bool Equals(object obj)
         {
-            return
-                other is Flex f &&
-                f.flexValue == flexValue &&
-                f.child.IsSame(child);
+            var flex = obj as Flex;
+            return flex != null &&
+                   EqualityComparer<Widget>.Default.Equals(child, flex.child) &&
+                   flexValue == flex.flexValue;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1614855968;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Widget>.Default.GetHashCode(child);
+            hashCode = hashCode * -1521134295 + flexValue.GetHashCode();
+            return hashCode;
         }
     }
 }

--- a/Flighter/Core/Image.cs
+++ b/Flighter/Core/Image.cs
@@ -101,6 +101,26 @@ namespace Flighter.Core
                 ? new Clip(widget) as Widget
                 : widget;
         }
+
+        public override bool Equals(object obj)
+        {
+            var image = obj as Image;
+            return image != null &&
+                   EqualityComparer<IImageHandle>.Default.Equals(imageHandle, image.imageHandle) &&
+                   EqualityComparer<Color?>.Default.Equals(color, image.color) &&
+                   fit == image.fit &&
+                   EqualityComparer<Alignment>.Default.Equals(alignment, image.alignment);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1833654010;
+            hashCode = hashCode * -1521134295 + EqualityComparer<IImageHandle>.Default.GetHashCode(imageHandle);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Color?>.Default.GetHashCode(color);
+            hashCode = hashCode * -1521134295 + fit.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<Alignment>.Default.GetHashCode(alignment);
+            return hashCode;
+        }
     }
 
     class _Image : DisplayWidget
@@ -113,6 +133,18 @@ namespace Flighter.Core
         }
 
         public override Element CreateElement() => new _ImageElement();
+
+        public override bool Equals(object obj)
+        {
+            var image = obj as _Image;
+            return image != null &&
+                   EqualityComparer<Image>.Default.Equals(this.image, image.image);
+        }
+
+        public override int GetHashCode()
+        {
+            return -1125144822 + EqualityComparer<Image>.Default.GetHashCode(image);
+        }
 
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)
         {

--- a/Flighter/Core/InputPoller.cs
+++ b/Flighter/Core/InputPoller.cs
@@ -21,9 +21,27 @@ namespace Flighter.Core
             this.callback = callback;
         }
 
+        public override bool Equals(object obj)
+        {
+            var poller = obj as InputPoller;
+            return poller != null &&
+                   base.Equals(obj) &&
+                   EqualityComparer<InputUpdateCallback>.Default.Equals(callback, poller.callback);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1390279012;
+            hashCode = hashCode * -1521134295 + base.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<InputUpdateCallback>.Default.GetHashCode(callback);
+            return hashCode;
+        }
+
         public override void OnUpdate(IInputPoller inputPoller)
         {
             callback?.Invoke(inputPoller);
         }
+
+
     }
 }

--- a/Flighter/Core/KeyListener.cs
+++ b/Flighter/Core/KeyListener.cs
@@ -22,6 +22,22 @@ namespace Flighter.Core
             this.onKeyEvent = onKeyEvent;
         }
 
+        public override bool Equals(object obj)
+        {
+            var listener = obj as KeyListener;
+            return listener != null &&
+                   base.Equals(obj) &&
+                   EqualityComparer<KeyEventCallback>.Default.Equals(onKeyEvent, listener.onKeyEvent);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 67157251;
+            hashCode = hashCode * -1521134295 + base.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<KeyEventCallback>.Default.GetHashCode(onKeyEvent);
+            return hashCode;
+        }
+
         public override void OnKeyEvent(KeyEventFilter filter, IInputPoller inputPoller)
         {
             onKeyEvent?.Invoke(filter, inputPoller);

--- a/Flighter/Core/LerpChange.cs
+++ b/Flighter/Core/LerpChange.cs
@@ -31,7 +31,9 @@ namespace Flighter.Core
         {
             this.value = value;
             this.builder = builder;
-            // TODO: Put restrictions on the value of this.
+
+            if (ratioPerSecond <= 0 || ratioPerSecond >= 1)
+                throw new ArgumentOutOfRangeException("ratioPerSecond");
             this.ratioPerSecond = ratioPerSecond;
             this.tickProvider = tickProvider;
             this.lerp = lerp;

--- a/Flighter/Core/LerpChange.cs
+++ b/Flighter/Core/LerpChange.cs
@@ -31,13 +31,38 @@ namespace Flighter.Core
         {
             this.value = value;
             this.builder = builder;
+            // TODO: Put restrictions on the value of this.
             this.ratioPerSecond = ratioPerSecond;
             this.tickProvider = tickProvider;
             this.lerp = lerp;
             this.stopCondition = stopCondition;
         }
-
+        
         public override State CreateState() => new LerpChangeSatate<T>();
+
+        public override bool Equals(object obj)
+        {
+            var change = obj as LerpChange<T>;
+            return change != null &&
+                   EqualityComparer<T>.Default.Equals(value, change.value) &&
+                   EqualityComparer<ValueBuilder<T>>.Default.Equals(builder, change.builder) &&
+                   EqualityComparer<TickProvider>.Default.Equals(tickProvider, change.tickProvider) &&
+                   ratioPerSecond == change.ratioPerSecond &&
+                   EqualityComparer<Lerp<T>>.Default.Equals(lerp, change.lerp) &&
+                   EqualityComparer<StopCondition<T>>.Default.Equals(stopCondition, change.stopCondition);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1708436396;
+            hashCode = hashCode * -1521134295 + EqualityComparer<T>.Default.GetHashCode(value);
+            hashCode = hashCode * -1521134295 + EqualityComparer<ValueBuilder<T>>.Default.GetHashCode(builder);
+            hashCode = hashCode * -1521134295 + EqualityComparer<TickProvider>.Default.GetHashCode(tickProvider);
+            hashCode = hashCode * -1521134295 + ratioPerSecond.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<Lerp<T>>.Default.GetHashCode(lerp);
+            hashCode = hashCode * -1521134295 + EqualityComparer<StopCondition<T>>.Default.GetHashCode(stopCondition);
+            return hashCode;
+        }
     }
 
     class LerpChangeSatate<T> : State
@@ -78,13 +103,12 @@ namespace Flighter.Core
         {
             if (!isLerping)
                 return;
-
-            var w = GetWidget<LerpChange<T>>();
-
             
             SetState(() =>
             {
-                curValue = w.lerp(curValue, w.value, 1 - (float)Math.Pow(w.ratioPerSecond, delta));
+                var w = GetWidget<LerpChange<T>>();
+
+                curValue = w.lerp(curValue, w.value, 1 - (float)Math.Pow(1 - w.ratioPerSecond, delta));
 
                 if (w.stopCondition?.Invoke(curValue, w.value) ?? false)
                     isLerping = false;

--- a/Flighter/Core/LerpChange.cs
+++ b/Flighter/Core/LerpChange.cs
@@ -76,12 +76,12 @@ namespace Flighter.Core
 
             var w = GetWidget<LerpChange<T>>();
 
-            if (w?.stopCondition(curValue, w.value) ?? false)
+            if (w.stopCondition?.Invoke(curValue, w.value) ?? false)
             {
                 isLerping = false;
                 return;
             }
-
+            
             SetState(() =>
             {
                 curValue = w.lerp(curValue, w.value, 1 - (float)Math.Pow(w.ratioPerSecond, delta));

--- a/Flighter/Core/MouseListener.cs
+++ b/Flighter/Core/MouseListener.cs
@@ -21,6 +21,16 @@ namespace Flighter.Core
             this.onMouseEvent = onMouseEvent;
         }
 
+        public override bool Equals(object obj) => false;
+
+        public override int GetHashCode()
+        {
+            var hashCode = 446973263;
+            hashCode = hashCode * -1521134295 + base.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<MouseEventCallback>.Default.GetHashCode(onMouseEvent);
+            return hashCode;
+        }
+
         public override void OnMouseEvent(MouseEventFilter filter, IInputPoller inputPoller)
         {
             onMouseEvent?.Invoke(filter, inputPoller);

--- a/Flighter/Core/Padding.cs
+++ b/Flighter/Core/Padding.cs
@@ -48,12 +48,20 @@ namespace Flighter.Core
             this.edgetInsets = edgetInsets;
         }
 
-        public override bool IsSame(Widget other)
+        public override bool Equals(object obj)
         {
-            return 
-                other is Padding p && 
-                p.child == child && 
-                p.edgetInsets.Equals(edgetInsets);
+            var padding = obj as Padding;
+            return padding != null &&
+                   EqualityComparer<Widget>.Default.Equals(child, padding.child) &&
+                   EqualityComparer<EdgetInsets>.Default.Equals(edgetInsets, padding.edgetInsets);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -867541505;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Widget>.Default.GetHashCode(child);
+            hashCode = hashCode * -1521134295 + EqualityComparer<EdgetInsets>.Default.GetHashCode(edgetInsets);
+            return hashCode;
         }
 
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)

--- a/Flighter/Core/Positioned.cs
+++ b/Flighter/Core/Positioned.cs
@@ -24,8 +24,16 @@ namespace Flighter.Core
         {
             var childNode = node.AddChildWidget(child, context);
             childNode.Offset = offset;
+            
+            // TODO: Better doc
+            // If the offset is negative, we will end up returning a size less than that of the child.
+            // This is *mostly* the expectation. Really, the expectation is for children to stay within 
+            // the bounds of their parent, and we cannot account for when it goes outside.
+            var size = childNode.size.ToPoint() + offset;
+            size.x = Math.Max(0, size.x);
+            size.y = Math.Max(0, size.y);
 
-            return new BuildResult(childNode.size);
+            return new BuildResult(size.ToSize());
         }
     }
 }

--- a/Flighter/Core/Positioned.cs
+++ b/Flighter/Core/Positioned.cs
@@ -15,9 +15,20 @@ namespace Flighter.Core
             this.offset = offset;
         }
 
-        public override bool IsSame(Widget other)
+        public override bool Equals(object obj)
         {
-            return base.IsSame(other);
+            var positioned = obj as Positioned;
+            return positioned != null &&
+                   EqualityComparer<Widget>.Default.Equals(child, positioned.child) &&
+                   EqualityComparer<Point>.Default.Equals(offset, positioned.offset);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1240603729;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Widget>.Default.GetHashCode(child);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Point>.Default.GetHashCode(offset);
+            return hashCode;
         }
 
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)

--- a/Flighter/Core/Row.cs
+++ b/Flighter/Core/Row.cs
@@ -4,15 +4,8 @@ using System.Text;
 
 namespace Flighter.Core
 {
-    public class Row : StatelessWidget
+    public class Row : SequenceLayout
     {
-        public readonly List<Widget> children;
-        public readonly HorizontalDirection horizontalDirection;
-        public readonly VerticalDirection verticalDirection;
-        public readonly MainAxisAlignment mainAxisAlignment;
-        public readonly CrossAxisAlignment crossAxisAlignment;
-        public readonly MainAxisSize mainAxisSize;
-        
         public Row(
             List<Widget> children,
             HorizontalDirection horizontalDirection = HorizontalDirection.LeftToRight,
@@ -20,23 +13,24 @@ namespace Flighter.Core
             MainAxisAlignment mainAxisAlignment = MainAxisAlignment.Start,
             CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.Start,
             MainAxisSize mainAxisSize = MainAxisSize.Max)
+            : base(
+                  children,
+                  Axis.Horizontal,
+                  horizontalDirection,
+                  verticalDirection,
+                  mainAxisAlignment,
+                  crossAxisAlignment,
+                  mainAxisSize)
+        { }
+
+        public override bool Equals(object obj)
         {
-            this.children = children;
-            this.horizontalDirection = horizontalDirection;
-            this.verticalDirection = verticalDirection;
-            this.mainAxisAlignment = mainAxisAlignment;
-            this.crossAxisAlignment = crossAxisAlignment;
-            this.mainAxisSize = mainAxisSize;
+            return base.Equals(obj);
         }
 
-        public override Widget Build(BuildContext context)
-            => new SequenceLayout(
-                children,
-                Axis.Horizontal,
-                horizontalDirection,
-                verticalDirection,
-                mainAxisAlignment,
-                crossAxisAlignment,
-                mainAxisSize);
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }

--- a/Flighter/Core/SequenceLayout.cs
+++ b/Flighter/Core/SequenceLayout.cs
@@ -85,8 +85,8 @@ namespace Flighter.Core
 
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)
         {
-            if (float.IsPositiveInfinity(MaxOnMain(context)))
-                throw new Exception("Main axis cannot be unbounded.");
+            if (float.IsPositiveInfinity(MaxOnMain(context)) && mainAxisSize != MainAxisSize.Min)
+                throw new Exception("Main axis must be bound.");
 
             Dictionary<Widget, WidgetNodeBuilder> widgetNodes = new Dictionary<Widget, WidgetNodeBuilder>();
 
@@ -128,8 +128,7 @@ namespace Flighter.Core
                 });
             }
 
-            float maxMainSize = MaxOnMain(context);
-            float freeSpaceOnMain = maxMainSize - totalMainSize;
+            float freeSpaceOnMain = RemainingOnMain(context, totalMainSize);
             float runningMainOffset = StartOffsetOnMain(freeSpaceOnMain, children.Count);
             float mainSpace = SpaceOnMain(freeSpaceOnMain, children.Count);
 
@@ -140,7 +139,7 @@ namespace Flighter.Core
                 runningMainOffset += SizeOnMain(n) + mainSpace;
             });
 
-            return new BuildResult(FinalSize(maxMainSize, crossAxisSize));
+            return new BuildResult(FinalSize(context, totalMainSize, crossAxisSize));
         }
 
         List<Widget> LayoutOrder()
@@ -155,15 +154,25 @@ namespace Flighter.Core
 
             return children;
         }
-
-        Size FinalSize(float mainMax, float crossTotal)
+        
+        /// <param name="context"></param>
+        /// <param name="mainTotal">Without added space.</param>
+        /// <param name="crossTotal"></param>
+        /// <returns></returns>
+        Size FinalSize(BuildContext context, float mainTotal, float crossTotal)
         {
             switch (axis)
             {
                 case Axis.Horizontal:
-                    return new Size(mainMax, crossTotal);
+                    if (mainAxisSize == MainAxisSize.Max)
+                        return new Size(context.constraints.maxWidth, crossTotal);
+                    else
+                        return new Size(mainTotal, crossTotal);
                 case Axis.Vertical:
-                    return new Size(crossTotal, mainMax);
+                    if (mainAxisSize == MainAxisSize.Max)
+                        return new Size(crossTotal, context.constraints.maxHeight);
+                    else
+                        return new Size(crossTotal, mainTotal);
                 default:
                     throw new NotSupportedException();
             }
@@ -286,12 +295,12 @@ namespace Flighter.Core
             {
                 case Axis.Horizontal:
                     return new BuildContext(new BoxConstraints(
-                        minWidth: context.constraints.minWidth,
-                        maxWidth: context.constraints.maxWidth));
-                case Axis.Vertical:
-                    return new BuildContext(new BoxConstraints(
                         minHeight: context.constraints.minHeight,
                         maxHeight: context.constraints.maxHeight));
+                case Axis.Vertical:
+                    return new BuildContext(new BoxConstraints(
+                        minWidth: context.constraints.minWidth,
+                        maxWidth: context.constraints.maxWidth));
                 default:
                     throw new NotSupportedException();
             }

--- a/Flighter/Core/SequenceLayout.cs
+++ b/Flighter/Core/SequenceLayout.cs
@@ -87,8 +87,8 @@ namespace Flighter.Core
         {
             if (float.IsPositiveInfinity(MaxOnMain(context)) && mainAxisSize != MainAxisSize.Min)
                 throw new Exception("Main axis must be bound.");
-
-            Dictionary<Widget, WidgetNodeBuilder> widgetNodes = new Dictionary<Widget, WidgetNodeBuilder>();
+            
+            Dictionary<Widget, WidgetNodeBuilder> widgetNodes = new Dictionary<Widget, WidgetNodeBuilder>(new WidgetEquality());
 
             List<Widget> absoluteChildren = new List<Widget>();
             List<Flex> flexChildren = new List<Flex>();
@@ -390,6 +390,32 @@ namespace Flighter.Core
                 default:
                     throw new NotSupportedException();
             }
+        }
+
+        public override bool Equals(object obj)
+        {
+            var layout = obj as SequenceLayout;
+            return layout != null &&
+                   EqualityComparer<List<Widget>>.Default.Equals(children, layout.children) &&
+                   axis == layout.axis &&
+                   horizontalDirection == layout.horizontalDirection &&
+                   verticalDirection == layout.verticalDirection &&
+                   mainAxisAlignment == layout.mainAxisAlignment &&
+                   crossAxisAlignment == layout.crossAxisAlignment &&
+                   mainAxisSize == layout.mainAxisSize;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1852071883;
+            hashCode = hashCode * -1521134295 + EqualityComparer<List<Widget>>.Default.GetHashCode(children);
+            hashCode = hashCode * -1521134295 + axis.GetHashCode();
+            hashCode = hashCode * -1521134295 + horizontalDirection.GetHashCode();
+            hashCode = hashCode * -1521134295 + verticalDirection.GetHashCode();
+            hashCode = hashCode * -1521134295 + mainAxisAlignment.GetHashCode();
+            hashCode = hashCode * -1521134295 + crossAxisAlignment.GetHashCode();
+            hashCode = hashCode * -1521134295 + mainAxisSize.GetHashCode();
+            return hashCode;
         }
     }
 }

--- a/Flighter/Core/Spacer.cs
+++ b/Flighter/Core/Spacer.cs
@@ -8,5 +8,15 @@ namespace Flighter.Core
     {
         public Spacer(float flexValue = 1)
             : base(new EmptyBox(), flexValue) { }
+
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }

--- a/Flighter/Core/Stack.cs
+++ b/Flighter/Core/Stack.cs
@@ -13,6 +13,13 @@ namespace Flighter.Core
             this.children = children;
         }
 
+        public override bool Equals(object obj) => false;
+
+        public override int GetHashCode()
+        {
+            return 1458441378 + EqualityComparer<List<Widget>>.Default.GetHashCode(children);
+        }
+
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)
         {
             float maxWidth, maxHeight;

--- a/Flighter/Core/Text.cs
+++ b/Flighter/Core/Text.cs
@@ -16,17 +16,26 @@ namespace Flighter.Core
             this.data = data;
             this.style = style;
         }
-
-        public override bool IsSame(Widget other)
-        {
-            return other is Text t &&
-                data == t.data &&
-                style.Equals(t.style);
-        }
-
+        
         public override Element CreateElement()
         {
             return new TextElement();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var text = obj as Text;
+            return text != null &&
+                   data == text.data &&
+                   EqualityComparer<TextStyle?>.Default.Equals(style, text.style);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 362845251;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(data);
+            hashCode = hashCode * -1521134295 + EqualityComparer<TextStyle?>.Default.GetHashCode(style);
+            return hashCode;
         }
 
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)

--- a/Flighter/Core/Text.cs
+++ b/Flighter/Core/Text.cs
@@ -31,6 +31,8 @@ namespace Flighter.Core
 
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)
         {
+            // TODO: Currently just taking up as much space as possible.
+            //       Should take min space where possible.
             return new BuildResult(context.constraints.MaxSize);
         }
     }

--- a/Flighter/Core/ValueChangeBuilder.cs
+++ b/Flighter/Core/ValueChangeBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Flighter.Core
 {
@@ -34,6 +35,22 @@ namespace Flighter.Core
         }
 
         public override State CreateState() => new ValueChangeBuliderState<T>();
+
+        public override bool Equals(object obj)
+        {
+            var builder = obj as ValueChangeBuilder<T>;
+            return builder != null &&
+                   EqualityComparer<ValueBuilder<T>>.Default.Equals(this.builder, builder.builder) &&
+                   EqualityComparer<ValueChangeNotifier<T>>.Default.Equals(notifier, builder.notifier);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -746545925;
+            hashCode = hashCode * -1521134295 + EqualityComparer<ValueBuilder<T>>.Default.GetHashCode(builder);
+            hashCode = hashCode * -1521134295 + EqualityComparer<ValueChangeNotifier<T>>.Default.GetHashCode(notifier);
+            return hashCode;
+        }
     }
 
     class ValueChangeBuliderState<T> : State

--- a/Flighter/Element.cs
+++ b/Flighter/Element.cs
@@ -7,7 +7,7 @@ namespace Flighter
     /// </summary>
     public abstract class Element
     {
-        protected WidgetNode widgetNode;
+        public WidgetNode widgetNode { get; private set; }
         public W GetWidget<W>() where W : Widget
         {
             return widgetNode?.widget as W;

--- a/Flighter/ElementNode.cs
+++ b/Flighter/ElementNode.cs
@@ -188,7 +188,7 @@ namespace Flighter
             for (int i = 0; i < indent; ++i)
                 r += "-";
 
-            r += element.Name + (IsDirty? "*\n" : "\n");
+            r += element.Name + (IsDirty? "*" : "") + (HasDirtyChild? "+\n" : "\n");
 
             foreach (var c in children)
                 r += c.Print(indent + 1);

--- a/Flighter/Input/Input.cs
+++ b/Flighter/Input/Input.cs
@@ -53,8 +53,6 @@ namespace Flighter.Input
 
         public void DistributeUpdates(IEnumerable<IInputSubscriber> subscribers)
         {
-            // TODO: Need to give updates to widgets that don't care about mouse hovering...
-            //       Don't currently have a good way to gather those.
             foreach (var s in subscribers)
             {
                 if (s.KeyEventsToReceive != null)

--- a/Flighter/Input/InputWidget.cs
+++ b/Flighter/Input/InputWidget.cs
@@ -35,5 +35,17 @@ namespace Flighter.Input
         public virtual void OnMouseEvent(MouseEventFilter filter, IInputPoller inputPoller) { }
 
         public virtual void OnUpdate(IInputPoller inputPoller) { }
+
+        public override bool Equals(object obj) => false;
+
+        public override int GetHashCode()
+        {
+            var hashCode = 387291533;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Widget>.Default.GetHashCode(child);
+            hashCode = hashCode * -1521134295 + EqualityComparer<IEnumerable<KeyEventFilter>>.Default.GetHashCode(KeyEventsToReceive);
+            hashCode = hashCode * -1521134295 + EqualityComparer<IEnumerable<MouseEventFilter>>.Default.GetHashCode(MouseEventsToReceive);
+            hashCode = hashCode * -1521134295 + onlyWhileHovering.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Flighter/Math.cs
+++ b/Flighter/Math.cs
@@ -87,6 +87,26 @@ namespace Flighter
         {
             return "Width: " + width + ", Height:" + height;
         }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Size))
+            {
+                return false;
+            }
+
+            var size = (Size)obj;
+            return width == size.width &&
+                   height == size.height;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1263118649;
+            hashCode = hashCode * -1521134295 + width.GetHashCode();
+            hashCode = hashCode * -1521134295 + height.GetHashCode();
+            return hashCode;
+        }
     }
 
     public struct BoxConstraints
@@ -126,7 +146,7 @@ namespace Flighter
 
             CheckConstraints();
         }
-        
+
         /// <summary>
         /// The biggest size which satisfies the constrainst, if they are bounded.
         /// If a dimension is unbounded, the min will be returned.
@@ -169,6 +189,36 @@ namespace Flighter
                 minWidth < 0 || maxWidth < minWidth)
                 throw new BoxConstrainstException();
         }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is BoxConstraints))
+            {
+                return false;
+            }
+
+            var constraints = (BoxConstraints)obj;
+            return minHeight == constraints.minHeight &&
+                   maxHeight == constraints.maxHeight &&
+                   minWidth == constraints.minWidth &&
+                   maxWidth == constraints.maxWidth;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 467709450;
+            hashCode = hashCode * -1521134295 + minHeight.GetHashCode();
+            hashCode = hashCode * -1521134295 + maxHeight.GetHashCode();
+            hashCode = hashCode * -1521134295 + minWidth.GetHashCode();
+            hashCode = hashCode * -1521134295 + maxWidth.GetHashCode();
+            return hashCode;
+        }
+
+        public override string ToString()
+            => "Min width:" + minWidth
+            + ", Max width:" + maxWidth
+            + ", Min height:" + minHeight
+            + ", Max height:" + maxHeight;
     }
 
     public class BoxConstrainstException : Exception { }

--- a/Flighter/Math.cs
+++ b/Flighter/Math.cs
@@ -126,7 +126,7 @@ namespace Flighter
 
             CheckConstraints();
         }
-
+        
         /// <summary>
         /// The biggest size which satisfies the constrainst, if they are bounded.
         /// If a dimension is unbounded, the min will be returned.
@@ -141,6 +141,21 @@ namespace Flighter
                 return new Size(width, height);
             }
         }
+
+        /// <summary>
+        /// Create a new BoxConstraints based on this one, changing only those values which are provided.
+        /// </summary>
+        /// <returns></returns>
+        public BoxConstraints From(
+            float? minWidth = null,
+            float? maxWidth = null,
+            float? minHeight = null,
+            float? maxHeight = null)
+            => new BoxConstraints(
+                minWidth: minWidth ?? this.minWidth,
+                maxWidth: maxWidth ?? this.maxWidth,
+                minHeight: minHeight ?? this.minHeight,
+                maxHeight: maxHeight ?? this.maxHeight);
 
         public bool IsUnconstrained => float.IsPositiveInfinity(maxHeight) || float.IsPositiveInfinity(maxWidth);
 

--- a/Flighter/RootWidget.cs
+++ b/Flighter/RootWidget.cs
@@ -11,8 +11,7 @@ namespace Flighter
             Widget child,
             BuildContext initialBuildContext,
             IDisplayRect parentRect,
-            ComponentProvider componentProvider,
-            Input.Input input)
+            ComponentProvider componentProvider)
         {
             var rootWidget = new RootWidget(child);
             var rootElementNode = new RootElementNode(parentRect, componentProvider);
@@ -40,8 +39,17 @@ namespace Flighter
 
         public override BuildResult Layout(BuildContext context, WidgetNodeBuilder node)
         {
+            if (context.constraints.IsUnconstrained)
+                throw new Exception("Root constraints much be constrained.");
+
+            // TODO: We don't want to rebuild the root widget, as it could mess up special root connections.
+            //       ; root should be persistent.
+            //       So, the size returned cannot change. In reality, the size reported by root shouldn't matter too much,
+            //       but still ought to be accurate. So really, here we should return the max size possible.l
+            //       Currently returning the constraints max size, which above is required to be constrained.
+            //       This is *probably* fine, but should double check.
             var childNode = node.AddChildWidget(child, context);
-            return new BuildResult(childNode.size);
+            return new BuildResult(context.constraints.MaxSize);
         }
     }
 }

--- a/Flighter/RootWidget.cs
+++ b/Flighter/RootWidget.cs
@@ -42,12 +42,6 @@ namespace Flighter
             if (context.constraints.IsUnconstrained)
                 throw new Exception("Root constraints much be constrained.");
 
-            // TODO: We don't want to rebuild the root widget, as it could mess up special root connections.
-            //       ; root should be persistent.
-            //       So, the size returned cannot change. In reality, the size reported by root shouldn't matter too much,
-            //       but still ought to be accurate. So really, here we should return the max size possible.l
-            //       Currently returning the constraints max size, which above is required to be constrained.
-            //       This is *probably* fine, but should double check.
             var childNode = node.AddChildWidget(child, context);
             return new BuildResult(context.constraints.MaxSize);
         }

--- a/Flighter/State.cs
+++ b/Flighter/State.cs
@@ -21,7 +21,7 @@ namespace Flighter
 
         bool isDirty = false;
 
-        public void SetStateElement(StateElement stateElement)
+        internal void SetStateElement(StateElement stateElement)
         {
             this.stateElement = stateElement;
         }
@@ -44,7 +44,7 @@ namespace Flighter
         /// <summary>
         /// Call all the actions passed to <see cref="SetState(Action)"/> since the last time this was called.
         /// </summary>
-        public void InvokeUpdates()
+        internal void InvokeUpdates()
         {
             // Make a local copy incase updates queue new updates.
             var actions = updates.ToArray();

--- a/Flighter/State.cs
+++ b/Flighter/State.cs
@@ -11,13 +11,11 @@ namespace Flighter
         protected W GetWidget<W>() where W : Widget
         {
             return (stateElement?.GetWidget<W>() 
-                ?? stateElement?.builder?.widget 
-                ?? initWidget) as W
+                ?? stateElement?.Builder?.widget) as W
                 ?? throw new Exception("Could not get widget!");
         }
 
         StateElement stateElement;
-        Widget initWidget;
 
         readonly Queue<Action> updates = new Queue<Action>();
 
@@ -29,17 +27,7 @@ namespace Flighter
         }
 
         /// <summary>
-        /// Set this State's widget.
-        /// To be used when TODO: Finish doc
-        /// </summary>
-        /// <param name="widget"></param>
-        public void SetInitWidget(StatefulWidget widget)
-        {
-            initWidget = widget;
-        }
-
-        /// <summary>
-        /// Called once the state has been added to the element tree.
+        /// Called once when the state has been added to the element tree.
         /// The State's widget will be avalible at this point, but not before.
         /// </summary>
         public virtual void Init() { }
@@ -82,6 +70,8 @@ namespace Flighter
             {
                 if (stateElement == null)
                     throw new NullReferenceException("State's element cannot be null when setting state.");
+
+                stateElement.StateSet();
 
                 isDirty = true;
             }

--- a/Flighter/State.cs
+++ b/Flighter/State.cs
@@ -30,7 +30,7 @@ namespace Flighter
 
         /// <summary>
         /// Set this State's widget.
-        /// To be used when 
+        /// To be used when TODO: Finish doc
         /// </summary>
         /// <param name="widget"></param>
         public void SetInitWidget(StatefulWidget widget)
@@ -52,8 +52,11 @@ namespace Flighter
         /// Called when the state's element is removed from the element tree.
         /// </summary>
         public virtual void Dispose() { }
-
-        public void Updated()
+        
+        /// <summary>
+        /// Call all the actions passed to <see cref="SetState(Action)"/> since the last time this was called.
+        /// </summary>
+        public void InvokeUpdates()
         {
             // Make a local copy incase updates queue new updates.
             var actions = updates.ToArray();
@@ -65,15 +68,22 @@ namespace Flighter
                 action();
         }
 
+        /// <summary>
+        /// Mark this widget as needing to be rebuilt.
+        /// </summary>
+        /// <param name="action">The state changing action. Will be invoked right before the State is rebuilt.
+        /// One can make changes outside this method, but the changes will not be displayed until the tree happens to rebuild.</param>
         protected void SetState(Action action)
         {
             if (action != null)
                 updates.Enqueue(action);
 
-            if (!isDirty && stateElement != null)
+            if (!isDirty)
             {
+                if (stateElement == null)
+                    throw new NullReferenceException("State's element cannot be null when setting state.");
+
                 isDirty = true;
-                stateElement?.StateSet();
             }
         }
     }

--- a/Flighter/StateElement.cs
+++ b/Flighter/StateElement.cs
@@ -41,18 +41,7 @@ namespace Flighter
 
         protected override void _Update()
         {
-            // Called when the state should be rebuilt.
-
-            // First we let State carry out updates.
-            state.Updated();
-
-            // Then rebuild its widget.
-            var context = widgetNode.buildContext;
-            var widget = state.Build(context);
-
-            widgetNode.ReplaceChildren(new List<(Widget, BuildContext)> {
-                (widget, context)
-            });
+            state.InvokeUpdates();
         }
 
         protected override void _WidgetNodeChanged()

--- a/Flighter/StateElement.cs
+++ b/Flighter/StateElement.cs
@@ -14,7 +14,7 @@ namespace Flighter
         /// Provided so the state can perform an initial build.
         /// Otherwise, the state would have no way to access the widget.
         /// </summary>
-        public readonly WidgetNodeBuilder builder;
+        public WidgetNodeBuilder Builder;
 
         /// <summary>
         /// 
@@ -22,10 +22,9 @@ namespace Flighter
         /// <param name="state"></param>
         /// <param name="builder">Only needed when the state is being
         /// created from a <see cref="WidgetNodeBuilder"/></param>
-        public StateElement(State state, WidgetNodeBuilder builder = null)
+        public StateElement(State state)
         {
             this.state = state ?? throw new ArgumentNullException();
-            this.builder = builder;
             this.state.SetStateElement(this);
         }
 
@@ -34,18 +33,15 @@ namespace Flighter
             setDirty?.Invoke();
         }
         
-        protected override void _Init()
-        {
-            state.Init();
-        }
-
-        protected override void _Update()
-        {
-            state.InvokeUpdates();
-        }
+        // The state is initiated when built in WidgetNodeBuilder, so nothing to do here!
+        protected override void _Init() { }
+        
+        protected override void _Update() { }
 
         protected override void _WidgetNodeChanged()
         {
+            // Once the widget node has been changed by an ElementNode it is safe to forget the builder.
+            Builder = null;
             state.WidgetChanged();
         }
 

--- a/Flighter/StateElement.cs
+++ b/Flighter/StateElement.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Flighter
 {
-    public class StateElement : Element
+    internal class StateElement : Element
     {
         public override string Name => "State";
 
@@ -28,17 +28,14 @@ namespace Flighter
             this.state.SetStateElement(this);
         }
 
-        public void StateSet()
-        {
-            setDirty?.Invoke();
-        }
+        internal void StateSet() => RequestRebuild();
         
         // The state is initiated when built in WidgetNodeBuilder, so nothing to do here!
         protected override void _Init() { }
         
         protected override void _Update() { }
 
-        protected override void _WidgetNodeChanged()
+        protected override void _WidgetNodeChanged(WidgetNode oldNode)
         {
             // Once the widget node has been changed by an ElementNode it is safe to forget the builder.
             Builder = null;

--- a/Flighter/Widget.cs
+++ b/Flighter/Widget.cs
@@ -1,16 +1,16 @@
-﻿namespace Flighter
+﻿using System.Collections.Generic;
+
+namespace Flighter
 {
+    public class WidgetEquality : IEqualityComparer<Widget>
+    {
+        public bool Equals(Widget x, Widget y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(Widget obj) => obj.GetHashCode();
+    }
+
     public abstract class Widget
     {
-        /// <summary>
-        /// As far as the widget tree is concerned, is this the same as <paramref name="other"/>?
-        /// During replacement, if this returns true, the original is kept, 
-        /// and the new widget is dropped.
-        /// </summary>
-        /// <param name="other"></param>
-        /// <returns></returns>
-        public virtual bool IsSame(Widget other) => this == other;
-
         /// <summary>
         /// Can this replace <paramref name="other"/> in the tree.
         /// By default, this returns true if both types are equal.

--- a/Flighter/WidgetNode.cs
+++ b/Flighter/WidgetNode.cs
@@ -120,8 +120,23 @@ namespace Flighter
         /// </summary>
         public void Rebuild()
         {
+            // TODO: I've cracked it! So this doesn't actually work:
+            //       Currently, we emancipate, create a copy, and add it back. All that IS working
+            //       as expected, except we always re add at the "bottom," so when we rebuild, the new widget will always
+            //       be at the end of it's parents list of children. To match our expectations,
+            //       this must be changed so the new widget node is placed in the same position.
+
+            //       ideally, we can actually keep the same widget node, and just apply the rebuild in place!
+            //       in reality, it might be more difficult.
+            
+
+            // The root widget may have a rebuild triggered if a child changed size,
+            // but the root should never be rebuilt.
+            if (widget is RootWidget)
+                return;
+
             // Local var because Emancipate sets this.parent null.
-            var parent = this.parent;
+            var parent = this.parent ?? throw new Exception("Cannot rebuild root node!");
             Emancipate();
             var b = new WidgetNodeBuilder(
                 forest,

--- a/Flighter/WidgetNode.cs
+++ b/Flighter/WidgetNode.cs
@@ -42,6 +42,8 @@ namespace Flighter
         Point? cachedElementOffset;
         Point? cachedAbsoluteOffset;
 
+        bool rebuilding = false;
+
         /// <summary>
         /// Constructs a widget node.
         /// Adds this as a child of <paramref name="parent"/>.
@@ -64,7 +66,7 @@ namespace Flighter
         {
             this.forest = forest ?? throw new ArgumentNullException("Must belong to a WidgetTree.");
             this.parent = parent;
-            parent?.children?.Add(this);
+            parent?.AddChildNode(this);
 
             if (parent != null && parent.forest != forest)
                 throw new Exception("Tree must be the same as parent tree.");
@@ -101,7 +103,7 @@ namespace Flighter
             ClearCachedOffsets();
 
             this.parent = parent ?? throw new ArgumentNullException();
-            parent.children.Add(this);
+            parent.AddChildNode(this);
             if (parent.forest != forest)
                 throw new Exception("Tree must be the same as the parent tree.");
 
@@ -137,7 +139,7 @@ namespace Flighter
 
             // Local var because Emancipate sets this.parent null.
             var parent = this.parent ?? throw new Exception("Cannot rebuild root node!");
-            Emancipate();
+            rebuilding = true;
             var b = new WidgetNodeBuilder(
                 forest,
                 widget,
@@ -303,6 +305,18 @@ namespace Flighter
                 condition: (w) => w.widget is InputWidget i
                                 && i.onlyWhileHovering)
             .ConvertAll((w) => w as InputWidget);
+
+        void AddChildNode(WidgetNode childNode)
+        {
+            var toReplace = children.FindIndex((w) => w.rebuilding);
+            if (toReplace != -1)
+            {
+                children.RemoveAt(toReplace);
+                children.Insert(toReplace, childNode);
+            }
+            else
+                children.Add(childNode);
+        }
 
         /// <summary>
         /// Get all element nodes that would attach to an ancestor.

--- a/Flighter/WidgetNodeBuilder.cs
+++ b/Flighter/WidgetNodeBuilder.cs
@@ -50,7 +50,6 @@ namespace Flighter
             else if (widget is StatefulWidget sfw)
             {
                 State state;
-
                 if (inheritedElementNode != null)
                 {
                     if (inheritedChildren == null || inheritedChildren.Count != 1)
@@ -58,20 +57,26 @@ namespace Flighter
 
                     elementNode = inheritedElementNode;
 
-                    state = (elementNode.element as StateElement)?.state
+                    var stateElement = elementNode.element as StateElement
                         ?? throw new Exception("StatefulWidget inherited nonStateElement!");
+                    stateElement.Builder = this;
 
-                    state.SetInitWidget(sfw);
+                    state = stateElement.state;
+                    // Manually call this to reflect the change to the builder.
+                    state.WidgetChanged();
+                    // This state has been around the block, and may have some scores to settle before rebuilding.
+                    state.InvokeUpdates();
                 }
                 else
                 {
                     state = sfw.CreateState();
-                    elementNode = new ElementNode(new StateElement(state, this), null);
-                    state.SetInitWidget(sfw);
+                    var stateElement = new StateElement(state);
+                    elementNode = new ElementNode(stateElement, null);
+
+                    stateElement.Builder = this;
                     state.Init();
                 }
-
-                state.InvokeUpdates();
+                
                 var child = state.Build(this.buildContext);
                 var childNode = AddChildWidget(child, this.buildContext);
 

--- a/Flighter/WidgetNodeBuilder.cs
+++ b/Flighter/WidgetNodeBuilder.cs
@@ -167,12 +167,12 @@ namespace Flighter
                 // Getting there! So the offsets update correctly, but with the drops, it seems the state isn't updating properly, but only with this enabled.
                 // On another note, some herristic anylis testing failed to show signifigant performance improvement... Need to see if this is even worth the effort...
 
-                if (toReplace.buildContext.Equals(context) && widget.Equals(toReplace.widget))
-                {
-                    var b = new WidgetNodeBuilder(toReplace);
-                    children.Add(b);
-                    return b;
-                }
+                //if (toReplace.buildContext.Equals(context) && widget.Equals(toReplace.widget))
+                //{
+                //    var b = new WidgetNodeBuilder(toReplace);
+                //    children.Add(b);
+                //    return b;
+                //}
                 
                 if (widget.CanReplace(toReplace.widget))
                 {

--- a/Flighter/WidgetNodeBuilder.cs
+++ b/Flighter/WidgetNodeBuilder.cs
@@ -37,64 +37,70 @@ namespace Flighter
             this.buildContext = buildContext;
             this.inheritedChildren = inheritedChildren;
 
-            if (widget is StatelessWidget slw)
+            switch (widget)
             {
-                if (inheritedElementNode != null)
-                    throw new Exception("StatelessWidget cannot inherit an element node!");
+                case StatelessWidget slw:
+                    {
+                        if (inheritedElementNode != null)
+                            throw new Exception("StatelessWidget cannot inherit an element node!");
 
-                var child = slw.Build(this.buildContext);
-                var childNode = AddChildWidget(child, this.buildContext);
+                        var child = slw.Build(this.buildContext);
+                        var childNode = AddChildWidget(child, this.buildContext);
 
-                size = childNode.size;
+                        size = childNode.size;
+                        break;
+                    }
+                case StatefulWidget sfw:
+                    {
+                        State state;
+                        if (inheritedElementNode != null)
+                        {
+                            if (inheritedChildren == null || inheritedChildren.Count != 1)
+                                throw new Exception("When StatefulWidgets inherit an element node, they must inherit exactly one child.");
+
+                            elementNode = inheritedElementNode;
+
+                            var stateElement = elementNode.element as StateElement
+                                ?? throw new Exception("StatefulWidget inherited nonStateElement!");
+                            stateElement.Builder = this;
+
+                            state = stateElement.state;
+                            // Manually call this to reflect the change to the builder.
+                            state.WidgetChanged();
+                            // This state has been around the block, and may have some scores to settle before rebuilding.
+                            state.InvokeUpdates();
+                        }
+                        else
+                        {
+                            state = sfw.CreateState();
+                            var stateElement = new StateElement(state);
+                            elementNode = new ElementNode(stateElement, null);
+
+                            stateElement.Builder = this;
+                            state.Init();
+                        }
+
+                        var child = state.Build(this.buildContext);
+                        var childNode = AddChildWidget(child, this.buildContext);
+
+                        size = childNode.size;
+                        break;
+                    }
+                case LayoutWidget lw:
+                    {
+                        if (lw is DisplayWidget dw)
+                        {
+                            elementNode = inheritedElementNode ?? new ElementNode(dw.CreateElement(), null);
+                        }
+                        else if (inheritedElementNode != null)
+                            throw new Exception("Pure layout widget cannot inherit element!");
+
+                        size = lw.Layout(buildContext, this).size;
+                        break;
+                    }
+                default:
+                    throw new Exception("Widget type \"" + widget.GetType() + "\" not handled!");
             }
-            else if (widget is StatefulWidget sfw)
-            {
-                State state;
-                if (inheritedElementNode != null)
-                {
-                    if (inheritedChildren == null || inheritedChildren.Count != 1)
-                        throw new Exception("When StatefulWidgets inherit an element node, they must inherit exactly one child.");
-
-                    elementNode = inheritedElementNode;
-
-                    var stateElement = elementNode.element as StateElement
-                        ?? throw new Exception("StatefulWidget inherited nonStateElement!");
-                    stateElement.Builder = this;
-
-                    state = stateElement.state;
-                    // Manually call this to reflect the change to the builder.
-                    state.WidgetChanged();
-                    // This state has been around the block, and may have some scores to settle before rebuilding.
-                    state.InvokeUpdates();
-                }
-                else
-                {
-                    state = sfw.CreateState();
-                    var stateElement = new StateElement(state);
-                    elementNode = new ElementNode(stateElement, null);
-
-                    stateElement.Builder = this;
-                    state.Init();
-                }
-                
-                var child = state.Build(this.buildContext);
-                var childNode = AddChildWidget(child, this.buildContext);
-
-                size = childNode.size;
-            }
-            else if (widget is LayoutWidget lw)
-            {
-                if (lw is DisplayWidget dw)
-                {
-                    elementNode = inheritedElementNode ?? new ElementNode(dw.CreateElement(), null);
-                }
-                else if (inheritedElementNode != null)
-                    throw new Exception("Pure layout widget cannot inherit element!");
-
-                size = lw.Layout(buildContext, this).size;
-            }
-            else
-                throw new Exception("Widget type \"" + widget.GetType() + "\" not handled!");
 
             if (inheritedChildren != null)
             {
@@ -158,7 +164,10 @@ namespace Flighter
                 var toReplace = inheritedChildren.Dequeue();
                 
                 // TODO: Figure out how to re-enable this.
-                if (false && toReplace.buildContext.Equals(context) && widget.IsSame(toReplace.widget))
+                // Getting there! So the offsets update correctly, but with the drops, it seems the state isn't updating properly, but only with this enabled.
+                // On another note, some herristic anylis testing failed to show signifigant performance improvement... Need to see if this is even worth the effort...
+
+                if (toReplace.buildContext.Equals(context) && widget.Equals(toReplace.widget))
                 {
                     var b = new WidgetNodeBuilder(toReplace);
                     children.Add(b);

--- a/Flighter/WidgetNodeBuilder.cs
+++ b/Flighter/WidgetNodeBuilder.cs
@@ -71,6 +71,7 @@ namespace Flighter
                     state.Init();
                 }
 
+                state.InvokeUpdates();
                 var child = state.Build(this.buildContext);
                 var childNode = AddChildWidget(child, this.buildContext);
 
@@ -150,16 +151,14 @@ namespace Flighter
             if (inheritedChildren?.Count > 0)
             {
                 var toReplace = inheritedChildren.Dequeue();
-
+                
                 if (toReplace.buildContext.Equals(context) && widget.IsSame(toReplace.widget))
                 {
                     var b = new WidgetNodeBuilder(toReplace);
                     children.Add(b);
                     return b;
                 }
-
-                // TODO This is the same code as in WidgetNode.ReplaceChildren...
-                //      Should probably consolidate.
+                
                 if (widget.CanReplace(toReplace.widget))
                 {
                     childElementNode = toReplace.TakeElementNode();

--- a/Flighter/WidgetNodeBuilder.cs
+++ b/Flighter/WidgetNodeBuilder.cs
@@ -157,7 +157,8 @@ namespace Flighter
             {
                 var toReplace = inheritedChildren.Dequeue();
                 
-                if (toReplace.buildContext.Equals(context) && widget.IsSame(toReplace.widget))
+                // TODO: Figure out how to re-enable this.
+                if (false && toReplace.buildContext.Equals(context) && widget.IsSame(toReplace.widget))
                 {
                     var b = new WidgetNodeBuilder(toReplace);
                     children.Add(b);
@@ -169,7 +170,7 @@ namespace Flighter
                     childElementNode = toReplace.TakeElementNode();
                     orphans = toReplace.EmancipateChildren();
                 }
-
+                
                 toReplace.Dispose();
             }
 

--- a/FlighterTest/StateElementTest.cs
+++ b/FlighterTest/StateElementTest.cs
@@ -9,7 +9,7 @@ namespace FlighterTest
     class TestStateElement : StateElement
     {
         public TestStateElement(State state)
-            : base(state, null) { }
+            : base(state) { }
 
         public void WrapSetStateCallback(Action callFirst)
         {

--- a/FlighterTest/StateTest.cs
+++ b/FlighterTest/StateTest.cs
@@ -19,7 +19,7 @@ namespace FlighterTest
 
             Assert.IsFalse(called);
 
-            s.Updated();
+            s.InvokeUpdates();
 
             Assert.IsTrue(called);
         }
@@ -38,10 +38,10 @@ namespace FlighterTest
             };
 
             s.SetState(ss);
-            s.Updated();
+            s.InvokeUpdates();
 
             Assert.AreEqual(1, timesRun);
-            s.Updated();
+            s.InvokeUpdates();
             Assert.AreEqual(2, timesRun);
         }
 

--- a/FlighterUnity/Display.cs
+++ b/FlighterUnity/Display.cs
@@ -138,8 +138,7 @@ namespace FlighterUnity
                 widget,
                 new BuildContext(constraints),
                 rect,
-                componentProvider,
-                inputProvider?.GetInput() ?? NoInput.Input);
+                componentProvider);
 
             inputProvider?.AddRoot(root.Item1);
 

--- a/FlighterUnity/RootController.cs
+++ b/FlighterUnity/RootController.cs
@@ -35,6 +35,7 @@ namespace FlighterUnity
 
         void Update()
         {
+            elementRoot?.DoRebuilds();
             elementRoot?.Update();
         }
     }


### PR DESCRIPTION
Before this, there were many subtle issues, and one big one: if a widgets state change causes it to change size, parent widgets were not updated. This meant a complex layout would quickly become incorrect.

To correct this, a large change was introduced, with the main idea of separating and redefining the ideas of "Rebuilding" and "Updating."

Rebuilding: Causes the *widget* tree to rebuild. This rebuild behaves the same as an initial build. If the rebuild changes the widgets size, this widget will call "ChildSizeChanged" on the parent, who may in turn do a rebuild...

Updating: The actual process of updating an element wrt a rebuild.

Before, to refresh an element tree, one would simply call ElementNode.Update
Not, one first calls ElementNode.DoRebuilds, followed by ElementNode.Update.

Along with that large conceptual change, there is a whole host of other fixes and reworks!